### PR TITLE
Use standard binary checking trick

### DIFF
--- a/circuits/circom/Sha256.circom
+++ b/circuits/circom/Sha256.circom
@@ -185,14 +185,7 @@ template VerifyPaddedBits(padded_length) {
 // Ensures that the input is either 0 or 1
 template IsBinary() {
     signal input in;
-    component a = IsEqual();
-    a.in[0] <== in;
-    a.in[1] <== 0;
-    component b = IsEqual();
-    b.in[0] <== in;
-    b.in[1] <== 1;
-
-    a.out + b.out === 1;
+    a * (a - 1) === 0;
 }
 
 // Outputs the SHA256 hash of padded_bits.

--- a/circuits/circom/Sha256.circom
+++ b/circuits/circom/Sha256.circom
@@ -185,7 +185,7 @@ template VerifyPaddedBits(padded_length) {
 // Ensures that the input is either 0 or 1
 template IsBinary() {
     signal input in;
-    a * (a - 1) === 0;
+    in * (in - 1) === 0;
 }
 
 // Outputs the SHA256 hash of padded_bits.


### PR DESCRIPTION
Simplifies code and reduces constraints.
Note, circomlib's Num2Bits [uses this under the hood](https://github.com/iden3/circomlib/blob/master/circuits/bitify.circom#L33).