### PR TITLE
Move circom-helper to devdependencies

### DIFF
--- a/circuits/package.json
+++ b/circuits/package.json
@@ -25,13 +25,13 @@
     "dependencies": {
         "@noble/secp256k1": "1.3.4",
         "circom-ecdsa": "git://github.com/0xPARC/circom-ecdsa.git#d87eb7068cb35c951187093abe966275c1839ead",
-        "circom-helper": "0.3.5",
         "circomlib": "git://github.com/weijiekoh/circomlib.git#ac85e82c1914d47789e2032fb11ceb2cfdd38a2b",
         "snarkjs": "^0.5.0"
     },
     "devDependencies": {
         "@types/jest": "^29.0.3",
         "circom_tester": "^0.0.19",
+        "circom-helper": "0.3.5",
         "jest": "^29.0.3",
         "ts-jest": "^29.0.1",
         "typescript": "^4.8.3"


### PR DESCRIPTION
To allow compilation on import, like https://github.com/plume-sig/zk-nullifier-sig/issues/31